### PR TITLE
Feature/Phase3a: Hotbar Slice 1 (Core Data & Basic UI)

### DIFF
--- a/engines/saga2/hotbar.cpp
+++ b/engines/saga2/hotbar.cpp
@@ -1,0 +1,88 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "saga2/hotbar.h"
+#include "common/system.h"
+#include "common/str.h"
+#include "saga2/saga2.h"
+
+namespace Saga2 {
+
+// Hotbar State Implementation
+
+HotbarState::HotbarState() {
+	for (int charIdx = 0; charIdx < 3; ++charIdx) {
+		for (int slotIdx = 0; slotIdx < 9; ++slotIdx) {
+			_slots[charIdx][slotIdx].item = Nothing;
+			_slots[charIdx][slotIdx].proto = 0;
+		}
+	}
+}
+
+void HotbarState::assign(int characterIdx, int slotIdx, ObjectID obj) {
+	// Stub
+}
+
+void HotbarState::clear(int characterIdx, int slotIdx) {
+	// Stub
+}
+
+bool HotbarState::isPresent(int characterIdx, int slotIdx) const {
+	return false; // Stub
+}
+
+void HotbarState::validate(int characterIdx) {
+	// Stub
+}
+
+// Hotbar Panel Implementation
+
+constexpr int kHotbarSlotWidth = 64;
+constexpr int kHotbarSlotHeight = 36;
+constexpr int kHotbarPadding = 4;
+constexpr int kHotbarDimColorIndex = 10; // Placeholder index for dim border
+
+HotbarPanel::HotbarPanel(gPanelList &list, const Rect16 &box) : gControl(list, box, nullptr, 0) {
+}
+
+HotbarPanel::~HotbarPanel() {
+}
+
+void HotbarPanel::draw() {
+	gPort &port = _window._windowPort;
+	
+	int startX = _extent.x + kHotbarPadding;
+	int startY = _extent.y + 2;
+	
+	for (int i = 0; i < 9; ++i) {
+		Rect16 slotRect(startX + (kHotbarSlotWidth + kHotbarPadding) * i, startY, kHotbarSlotWidth, kHotbarSlotHeight);
+		
+		// Draw empty frame (dim border)
+		port.frameRect(slotRect, kHotbarDimColorIndex);
+		
+		// Draw number label
+		Common::String label = Common::String::format("%d", i + 1);
+		port.moveTo(slotRect.x + 2, slotRect.y + 2);
+		port.drawText(label.c_str(), 1);
+	}
+}
+
+} // End of namespace Saga2

--- a/engines/saga2/hotbar.cpp
+++ b/engines/saga2/hotbar.cpp
@@ -29,8 +29,8 @@ namespace Saga2 {
 // Hotbar State Implementation
 
 HotbarState::HotbarState() {
-	for (int charIdx = 0; charIdx < 3; ++charIdx) {
-		for (int slotIdx = 0; slotIdx < 9; ++slotIdx) {
+	for (int charIdx = 0; charIdx < kNumCharacters; ++charIdx) {
+		for (int slotIdx = 0; slotIdx < kMaxHotbarSlots; ++slotIdx) {
 			_slots[charIdx][slotIdx].item = Nothing;
 			_slots[charIdx][slotIdx].proto = 0;
 		}
@@ -60,6 +60,8 @@ constexpr int kHotbarSlotHeight = 36;
 constexpr int kHotbarPadding = 4;
 constexpr int kHotbarDimColorIndex = 10; // Placeholder index for dim border
 
+const char *const slotLabels[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
+
 HotbarPanel::HotbarPanel(gPanelList &list, const Rect16 &box) : gControl(list, box, nullptr, 0) {
 }
 
@@ -72,16 +74,15 @@ void HotbarPanel::draw() {
 	int startX = _extent.x + kHotbarPadding;
 	int startY = _extent.y + 2;
 	
-	for (int i = 0; i < 9; ++i) {
+	for (int i = 0; i < kMaxHotbarSlots; ++i) {
 		Rect16 slotRect(startX + (kHotbarSlotWidth + kHotbarPadding) * i, startY, kHotbarSlotWidth, kHotbarSlotHeight);
 		
 		// Draw empty frame (dim border)
 		port.frameRect(slotRect, kHotbarDimColorIndex);
 		
 		// Draw number label
-		Common::String label = Common::String::format("%d", i + 1);
 		port.moveTo(slotRect.x + 2, slotRect.y + 2);
-		port.drawText(label.c_str(), 1);
+		port.drawText(slotLabels[i], 1);
 	}
 }
 

--- a/engines/saga2/hotbar.h
+++ b/engines/saga2/hotbar.h
@@ -27,6 +27,9 @@
 
 namespace Saga2 {
 
+constexpr int kNumCharacters = 3;
+constexpr int kMaxHotbarSlots = 9;
+
 class HotbarState {
 public:
 	struct Slot {
@@ -35,7 +38,7 @@ public:
 	};
 
 private:
-	Slot _slots[3][9];
+	Slot _slots[kNumCharacters][kMaxHotbarSlots];
 
 public:
 	HotbarState();

--- a/engines/saga2/hotbar.h
+++ b/engines/saga2/hotbar.h
@@ -1,0 +1,59 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SAGA2_HOTBAR_H
+#define SAGA2_HOTBAR_H
+
+#include "saga2/objects.h"
+#include "saga2/panel.h"
+
+namespace Saga2 {
+
+class HotbarState {
+public:
+	struct Slot {
+		ObjectID item;
+		ProtoObjID proto;
+	};
+
+private:
+	Slot _slots[3][9];
+
+public:
+	HotbarState();
+	
+	void assign(int characterIdx, int slotIdx, ObjectID obj);
+	void clear(int characterIdx, int slotIdx);
+	bool isPresent(int characterIdx, int slotIdx) const;
+	void validate(int characterIdx);
+};
+
+class HotbarPanel : public gControl {
+public:
+	HotbarPanel(gPanelList &list, const Rect16 &box);
+	virtual ~HotbarPanel();
+
+	virtual void draw() override;
+};
+
+} // End of namespace Saga2
+
+#endif

--- a/engines/saga2/module.mk
+++ b/engines/saga2/module.mk
@@ -26,6 +26,7 @@ MODULE_OBJS := \
 	grequest.o \
 	gtext.o \
 	gtextbox.o \
+	hotbar.o \
 	hresmgr.o \
 	imagcach.o \
 	interp.o \

--- a/engines/saga2/saga2.cpp
+++ b/engines/saga2/saga2.cpp
@@ -150,6 +150,7 @@ Saga2Engine::~Saga2Engine() {
 	delete _tmm;
 	delete _cnm;
 	delete _hotbarState;
+	delete _hotbarPanel;
 
 	delete _imageCache;
 	delete _mTaskList;

--- a/engines/saga2/saga2.cpp
+++ b/engines/saga2/saga2.cpp
@@ -52,6 +52,7 @@
 #include "saga2/spelshow.h"
 #include "saga2/tilemode.h"
 #include "saga2/vpal.h"
+#include "saga2/hotbar.h"
 
 namespace Saga2 {
 
@@ -76,6 +77,8 @@ Saga2Engine::Saga2Engine(OSystem *syst, const SAGA2GameDescription *desc)
 	_calendar = nullptr;
 	_tmm = nullptr;
 	_cnm = nullptr;
+	_hotbarState = nullptr;
+	_hotbarPanel = nullptr;
 
 	_bandList = nullptr;
 	_mouseInfo = nullptr;
@@ -146,6 +149,7 @@ Saga2Engine::~Saga2Engine() {
 	delete _calendar;
 	delete _tmm;
 	delete _cnm;
+	delete _hotbarState;
 
 	delete _imageCache;
 	delete _mTaskList;
@@ -174,6 +178,7 @@ Common::Error Saga2Engine::run() {
 	_calendar = new CalendarTime;
 	_tmm = new TileModeManager;
 	_cnm = new ContainerManager;
+	_hotbarState = new HotbarState;
 
 	readConfig();
 

--- a/engines/saga2/saga2.h
+++ b/engines/saga2/saga2.h
@@ -84,6 +84,8 @@ class PaletteManager;
 class ActorManager;
 class CalendarTime;
 class TileModeManager;
+class HotbarState;
+class HotbarPanel;
 struct SAGA2GameDescription;
 
 enum {
@@ -148,6 +150,8 @@ public:
 	CalendarTime *_calendar;
 	TileModeManager *_tmm;
 	ContainerManager *_cnm;
+	HotbarState *_hotbarState;
+	HotbarPanel *_hotbarPanel;
 
 	WeaponStuff _weaponRack[kMaxWeapons];
 	weaponID _loadedWeapons;

--- a/engines/saga2/tilemode.cpp
+++ b/engines/saga2/tilemode.cpp
@@ -47,6 +47,8 @@
 #include "saga2/contain.h"
 #include "saga2/saveload.h"
 #include "saga2/oncall.h"
+#include "saga2/weapons.h"
+#include "saga2/hotbar.h"
 
 namespace Saga2 {
 
@@ -648,6 +650,8 @@ void TileModeSetup() {
 	//  Create a control covering the map area.
 	tileMapControl = new gStickyDragControl(*playControls, Rect16(kTileRectX, kTileRectY, kTileRectWidth, kTileRectHeight), 0, cmdClickTileMap);
 
+	g_vm->_hotbarPanel = new HotbarPanel(*tileControls, Rect16(0, 440, 640, 40));
+
 	//Enable Tile Mode Specific Controls
 	tileControls->enable(true);
 
@@ -675,6 +679,9 @@ void TileModeCleanup() {
 //	tileRes = NULL;
 
 	delete tileMapControl;
+
+	delete g_vm->_hotbarPanel;
+	g_vm->_hotbarPanel = nullptr;
 
 //	This Fixes the mousePanel That's not set up
 	g_vm->_toolBase->_mousePanel = nullptr;


### PR DESCRIPTION
## Summary
- Implemented `HotbarState` to manage 3 characters × 9 slots
- Created `HotbarPanel` UI component to render 9 slot frames
- Attached `HotbarPanel` to `TileMode` visibility lifecycle and engine startup/shutdown

## Test Plan
- [ ] Compile engine
- [ ] Enter Tile Mode and verify bottom border renders 9 numbered slots
- [ ] Open menu and verify slots disappear